### PR TITLE
support zig 0.12.0

### DIFF
--- a/examples/sniff/src/main.zig
+++ b/examples/sniff/src/main.zig
@@ -257,9 +257,8 @@ pub fn main() !void {
     }
 
     const address = net.Address.initIp4(.{ 127, 0, 0, 1 }, 25400);
-    var server = net.StreamServer.init(.{ .reuse_address = true });
+    var server = try address.listen(.{ .reuse_port = true });
     defer server.deinit();
-    try server.listen(address);
 
     print("Listening on {}\n", .{address});
 
@@ -294,7 +293,7 @@ fn print(comptime fmt_: [:0]const u8, args: anytype) void {
 const CurrentState = PacketKind;
 pub fn handleServerbound(
     a: Allocator,
-    conn: net.StreamServer.Connection,
+    conn: net.Server.Connection,
     options: Options,
 ) !void {
     @setEvalBranchQuota(10_000);

--- a/examples/statusserver/src/main.zig
+++ b/examples/statusserver/src/main.zig
@@ -13,9 +13,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
 
     const address = net.Address.initIp4(.{ 127, 0, 0, 1 }, 25565);
-    var server = net.StreamServer.init(.{ .reuse_address = true });
+    var server = try address.listen(.{ .reuse_port = true });
+
     defer server.deinit();
-    try server.listen(address);
     std.log.info("Status server listening on {}", .{address});
 
     var arena = std.heap.ArenaAllocator.init(gpa.allocator());
@@ -32,7 +32,7 @@ pub fn main() !void {
         };
     }
 }
-pub fn handleClient(a: Allocator, conn: net.StreamServer.Connection) !void {
+pub fn handleClient(a: Allocator, conn: net.Server.Connection) !void {
     defer conn.stream.close();
     var br = io.bufferedReader(conn.stream.reader());
 


### PR DESCRIPTION
Issue: https://github.com/regenerativep/zigmcp/issues/2

Currently blocker: `Packed` type
```
src/serde.zig:1012:50: error: no field named 'Packed' in enum 'builtin.Type.ContainerLayout'
if (v == .Struct and info.layout == .Packed)
```